### PR TITLE
fix evaluateExpression on maven wrapper

### DIFF
--- a/src/com/cloudogu/ces/cesbuildlib/Maven.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Maven.groovy
@@ -93,7 +93,10 @@ abstract class Maven implements Serializable {
 
     String evaluateExpression(String expression) {
         // See also: https://blog.soebes.de/blog/2018/06/09/help-plugin/
-        mvn("org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=${expression} -q -DforceStdout", false)
+        def evaluatedString = mvn("org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=${expression} -q -DforceStdout", false)
+        // we take only the last line of the evaluated expression,
+        // because in the case of maven wrapper the home and sometimes the download is printed before
+        return evaluatedString.trim().readLines().last()
     }
 
     @Deprecated

--- a/test/com/cloudogu/ces/cesbuildlib/MavenTest.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/MavenTest.groovy
@@ -104,6 +104,21 @@ class MavenTest {
     }
 
     @Test
+    void testGetMavenPropertyWithMavenWrapper() {
+        Maven mvn = new MavenWrapperForTest()
+        assertEquals("Unexpected property returned",
+                "org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=key -q -DforceStdout", mvn.getMavenProperty('key'))
+    }
+
+    @Test
+    void testGetMavenPropertyWithMavenWrapperNotYetDownloaded() {
+        Maven mvn = new MavenWrapperForTest()
+        mvn.downloaded = false
+        assertEquals("Unexpected property returned",
+                "org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=key -q -DforceStdout", mvn.getMavenProperty('key'))
+    }
+
+    @Test
     void testDeployToNexusRepositoryNoRepository() {
         mvn.deployToNexusRepository()
 
@@ -308,6 +323,31 @@ class MavenTest {
         def mvn(String args, boolean printStdOut) {
             mvnArgs = args
             return args
+        }
+    }
+
+    class MavenWrapperForTest extends Maven {
+
+        private boolean downloaded = true
+
+        MavenWrapperForTest() {
+            this(null)
+        }
+
+        MavenWrapperForTest(Object script) {
+            super(script)
+        }
+
+        def mvn(String args, boolean printStdOut) {
+            // maven wrapper starts mostly with the current working directory
+            String out = "/home/tricia/heartOfGold"
+            if (!downloaded) {
+                out += '\n--2020-03-11 15:07:29--  https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar'
+                out += '\nResolving repo.maven.apache.org (repo.maven.apache.org)... 151.101.12.215'
+                out += '\nMuch much more lines ...'
+            }
+            mvnArgs = args
+            return out + '\n' + args
         }
     }
 }


### PR DESCRIPTION
The evaluateExpression method is currently broken on mvnw.

Because the maven wrapper prints always its current working directory and if maven or the wrapper must be downloaded the output of this is printed as well.

This fix will ensure that only the last line of the maven evaluate goal is returned.