### PR TITLE
fixed SonarCloud with existing additional maven args

### DIFF
--- a/src/com/cloudogu/ces/cesbuildlib/SonarCloud.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/SonarCloud.groovy
@@ -29,6 +29,8 @@ class SonarCloud extends SonarQube {
         String repoName = git.repositoryName
 
         mvn.additionalArgs +=
+                // an additional space is required in the case of pre existing additionalArgs
+                " " +
                 "-Dsonar.pullrequest.base=${script.env.CHANGE_TARGET} " +
                 "-Dsonar.pullrequest.branch=${script.env.CHANGE_BRANCH} " +
                 "-Dsonar.pullrequest.key=${script.env.CHANGE_ID} "

--- a/test/com/cloudogu/ces/cesbuildlib/SonarCloudTest.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/SonarCloudTest.groovy
@@ -56,7 +56,7 @@ class SonarCloudTest {
         sonarCloud.analyzeWith(mavenMock)
 
         assertEquals(
-                '-Dsonar.pullrequest.base=develop -Dsonar.pullrequest.branch=feature/something ' +
+                ' -Dsonar.pullrequest.base=develop -Dsonar.pullrequest.branch=feature/something ' +
                 '-Dsonar.pullrequest.key=PR-42 -Dsonar.pullrequest.provider=GitHub ' +
                 '-Dsonar.pullrequest.github.repository=owner/repo ',
                 mavenMock.additionalArgs)
@@ -132,7 +132,7 @@ class SonarCloudTest {
         sonarCloud.analyzeWith(mavenMock)
 
         assertEquals(
-                '-Dsonar.pullrequest.base=develop -Dsonar.pullrequest.branch=feature/something ' +
+                ' -Dsonar.pullrequest.base=develop -Dsonar.pullrequest.branch=feature/something ' +
                         '-Dsonar.pullrequest.key=PR-42 -Dsonar.pullrequest.provider=bitbucketcloud ' +
                         '-Dsonar.pullrequest.bitbucketcloud.owner=orga ' +
                         '-Dsonar.pullrequest.bitbucketcloud.repository=repo ',

--- a/test/com/cloudogu/ces/cesbuildlib/SonarCloudTest.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/SonarCloudTest.groovy
@@ -63,6 +63,27 @@ class SonarCloudTest {
     }
 
     @Test
+    void pullRequestAnalysisWithExistingAdditionalArgs() {
+        scriptMock.expectedIsPullRequest = true
+        scriptMock.env = [
+                CHANGE_ID : 'PR-42',
+                CHANGE_TARGET : 'develop',
+                CHANGE_BRANCH : 'feature/something'
+        ]
+        scriptMock.expectedDefaultShRetValue = 'github.com/owner/repo'
+
+        mavenMock.additionalArgs = "-Pci"
+        sonarCloud.analyzeWith(mavenMock)
+
+        assertEquals(
+                '-Pci ' +
+                '-Dsonar.pullrequest.base=develop -Dsonar.pullrequest.branch=feature/something ' +
+                '-Dsonar.pullrequest.key=PR-42 -Dsonar.pullrequest.provider=GitHub ' +
+                '-Dsonar.pullrequest.github.repository=owner/repo ',
+                mavenMock.additionalArgs)
+    }
+
+    @Test
     void waitForQualityGatePullRequest() throws Exception {
         scriptMock.expectedQGate = [status: 'OK']
         scriptMock.expectedIsPullRequest = true


### PR DESCRIPTION
There is a missing space between existing additional maven args and those which are coming from SonarCloud. This results in parameters like the following:

```bash
mvn ... -Dsonar.organization=scm-manager -Pci-Dsonar.pullrequest.base=develop
```

This issue seams to occur only on pr builds e.g.:

https://oss.cloudogu.com/jenkins/job/scm-manager-plugins/job/scm-review-plugin/view/change-requests/job/PR-57/