### PR TITLE
Add retry for calls with credentials

### DIFF
--- a/src/com/cloudogu/ces/cesbuildlib/Git.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Git.groovy
@@ -4,6 +4,8 @@ class Git implements Serializable {
     private script
     Sh sh
     def credentials = null
+    def retryTimeout = 500
+    def maxRetries = 5
 
     Git(script, credentials) {
         this(script)
@@ -13,6 +15,22 @@ class Git implements Serializable {
     Git(script) {
         this.script = script
         this.sh = new Sh(script)
+    }
+
+    /**
+     * You can set the timeout between retries, when git calls with credentials fail. The default is 500 ms.
+     * @param retryTimeout The new timeout in milli seconds.
+     */
+    void setRetryTimeout(def retryTimeout) {
+        this.retryTimeout = retryTimeout;
+    }
+
+    /**
+     * You can set the maximum number of retries, when git calls with credentials fail. The default is 5.
+     * @param maxRetries The new maximum number of retries.
+     */
+    void setMaxRetries(def maxRetries) {
+        this.maxRetries = maxRetries;
     }
 
     def call(args) {
@@ -248,13 +266,28 @@ class Git implements Serializable {
      * This method executes the git command with a bash function as credential helper,
      * which return username and password from jenkins credentials.
      *
+     * If the script failes with exit code 128, this will retry the call up to 5 times
+     * before failing.
+     *
      * @param args git arguments
      */
     protected void executeGitWithCredentials(String args) {
         if (credentials) {
             script.withCredentials([script.usernamePassword(credentialsId: credentials,
                     passwordVariable: 'GIT_AUTH_PSW', usernameVariable: 'GIT_AUTH_USR')]) {
-                script.sh "git -c credential.helper=\"!f() { echo username='\$GIT_AUTH_USR'; echo password='\$GIT_AUTH_PSW'; }; f\" ${args}"
+                def pushResultCode = 128
+                def retryCount = 0
+                while (pushResultCode == 128 && retryCount < maxRetries) {
+                    if (retryCount > 0) {
+                        script.echo "Got error code ${pushResultCode} - retrying in ${retryTimeout} ms ..."
+                        sleep(retryTimeout)
+                    }
+                    ++retryCount
+                    pushResultCode = script.sh returnStatus: true, script: "git -c credential.helper=\"!f() { echo username='\$GIT_AUTH_USR'; echo password='\$GIT_AUTH_PSW'; }; f\" ${args}"
+                }
+                if (pushResultCode != 0) {
+                    script.error "Unable to execute git call. Retried ${retryCount} times. Last error code: ${pushResultCode}"
+                }
             }
         } else {
             script.sh "git ${args}"

--- a/src/com/cloudogu/ces/cesbuildlib/Git.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Git.groovy
@@ -266,8 +266,8 @@ class Git implements Serializable {
      * This method executes the git command with a bash function as credential helper,
      * which return username and password from jenkins credentials.
      *
-     * If the script failes with exit code 128, this will retry the call up to 5 times
-     * before failing.
+     * If the script failes with exit code 128, this will retry the call up to the
+     * configured max retries before failing.
      *
      * @param args git arguments
      */

--- a/src/com/cloudogu/ces/cesbuildlib/Git.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Git.groovy
@@ -284,6 +284,7 @@ class Git implements Serializable {
                     }
                     ++retryCount
                     pushResultCode = script.sh returnStatus: true, script: "git -c credential.helper=\"!f() { echo username='\$GIT_AUTH_USR'; echo password='\$GIT_AUTH_PSW'; }; f\" ${args}"
+                    pushResultCode = pushResultCode as int
                 }
                 if (pushResultCode != 0) {
                     script.error "Unable to execute git call. Retried ${retryCount} times. Last error code: ${pushResultCode}"

--- a/test/com/cloudogu/ces/cesbuildlib/GitTest.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/GitTest.groovy
@@ -240,17 +240,35 @@ class GitTest {
 
     @Test
     void push() {
+        ScriptMock scriptMock = new ScriptMock()
+        scriptMock.expectedShRetValueForScript.put('git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master', 0)
         git = new Git(scriptMock, 'creds')
         git.push('master')
     }
 
     @Test
     void pushNonHttps() {
+        ScriptMock scriptMock = new ScriptMock()
+        scriptMock.expectedShRetValueForScript.put('git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master', 0)
         git = new Git(scriptMock, 'creds')
         git.push('master')
 
-        assert scriptMock.actualShStringArgs.size() == 1
-        assert scriptMock.actualShStringArgs.get(0) == 'git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master'
+        assert scriptMock.actualShMapArgs.size() == 1
+        assert scriptMock.actualShMapArgs.get(0) == 'git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master'
+    }
+
+    @Test
+    void pushWithRetry() {
+        ScriptMock scriptMock = new ScriptMock()
+        scriptMock.expectedShRetValueForScript.put('git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master', [128, 128, 0])
+        git = new Git(scriptMock, 'creds')
+        git.retryTimeout = 1
+        git.push('master')
+
+        assert scriptMock.actualShMapArgs.size() == 3
+        assert scriptMock.actualShMapArgs.get(0) == 'git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master'
+        assert scriptMock.actualShMapArgs.get(1) == 'git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master'
+        assert scriptMock.actualShMapArgs.get(2) == 'git -c credential.helper="!f() { echo username=\'$GIT_AUTH_USR\'; echo password=\'$GIT_AUTH_PSW\'; }; f" push origin master'
     }
 
     @Test

--- a/test/com/cloudogu/ces/cesbuildlib/ScriptMock.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/ScriptMock.groovy
@@ -28,19 +28,23 @@ class ScriptMock {
 
     String sh(String args) {
         actualShStringArgs.add(args.toString())
-        if (expectedDefaultShRetValue == null) {
-            // toString() to make Map also match GStrings
-            return expectedShRetValueForScript.get(args.toString())
-        } else {
-            return expectedDefaultShRetValue
-        }
+        return getReturnValueFor(args)
     }
 
-    String sh(Map<String, String> args) {
-        // toString() to make Map also match GStrings
+    String sh(Map<String, Object> args) {
         actualShMapArgs.add(args.script.toString())
+        return getReturnValueFor(args.get('script'))
+    }
+
+    private Object getReturnValueFor(Object arg) {
         if (expectedDefaultShRetValue == null) {
-            return expectedShRetValueForScript.get(args.get('script').toString())
+            // toString() to make Map also match GStrings
+            def value = expectedShRetValueForScript.get(arg.toString())
+            if (value instanceof List) {
+                return ((List) value).removeAt(0)
+            } else {
+                return value
+            }
         } else {
             return expectedDefaultShRetValue
         }


### PR DESCRIPTION
With this, git calls with credentials (at the moment `git push`) will retry the call, when the exit code equals 128. The maximum number of retries and the timeout between retries can be set from external.