### PR TITLE
Adds executeWithCredentials to git.fetch()

### DIFF
--- a/src/com/cloudogu/ces/cesbuildlib/Git.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Git.groovy
@@ -211,7 +211,7 @@ class Git implements Serializable {
         // we need to configure remote,
         // because jenkins configures the remote only for the current branch
         script.sh "git config 'remote.origin.fetch' '+refs/heads/*:refs/remotes/origin/*'"
-        script.sh "git fetch --all"
+        executeGitWithCredentials "fetch --all"
     }
 
     /**


### PR DESCRIPTION
Fetching from a remote server will need Credentials in some cases.

Signed-off-by: Philipp Markiewka <philipp.markiewka@cloudogu.com>