### PR TITLE
Extensions to Git and Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,11 @@ Example from Jenkinsfile:
 
 ## Additional features provided by the `Docker.Image` class
 
+* `repoDigests()`: Returns the repo digests, a content addressable unique digest of an image that was pushed 
+   to or pulled  from repositories.  
+   If the image was built locally and not pushed, returns an empty list.  
+   If the image was pulled from or pushed to a repo, returns a list containing one item.  
+   If the image was pulled from or pushed to multiple repos, might also contain more than one digest.  
 * `mountJenkinsUser()`: Setting this to `true` provides the user that executes the build within docker container's `/etc/passwd`.
   This is necessary for some commands such as npm, ansible, git, id, etc. Those might exit with errors withouta user 
   present.

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ gitWithCreds 'https://your.repo' // Implicitly passed credentials
 * `git.commitMessage` -  Last commit message e.g. `Implements new functionality...` 
 * `git.commitHash` -  e.g. `fb1c8820df462272011bca5fddbe6933e91d69ed`
 * `git.commitHashShort` -  e.g. `fb1c882`
+* `git.areChangesStagedForCommit()` - `true` if changes are staged for commit. If `false`, `git.commit()` will fail. 
 * `git.repositoryUrl` -  e.g. `https://github.com/orga/repo.git`
 * `git.gitHubRepositoryName` -  e.g. `orga/repo`
 * Tags - Note that the git plugin might not fetch tags for all builds. Run `sh "git fetch --tags"` to make sure.

--- a/src/com/cloudogu/ces/cesbuildlib/Docker.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Docker.groovy
@@ -235,16 +235,32 @@ class Docker implements Serializable {
          * Runs docker tag to record a tag of this image (defaulting to the tag it already has). Will rewrite an
          * existing tag if one exists.
          */
-        void tag(String tagName = image().parsedId.tag, boolean force = true) {
+        void tag(String tagName, boolean force) {
             image().tag(tagName, force)
+        }
+        
+        void tag(String tagName) {
+            image().tag(tagName)
+        }
+        
+        void tag() {
+            image().tag()
         }
 
         /**
          * Pushes an image to the registry after tagging it as with the tag method. For example, you can use image().push
          * 'latest' to publish it as the latest version in its repository.
          */
-        void push(String tagName = image().parsedId.tag, boolean force = true) {
+        void push(String tagName, boolean force) {
             image().push(tagName, force)
+        }
+        
+        void push(String tagName) {
+            image().push(tagName)
+        }
+        
+        void push() {
+            image().push()
         }
 
         /**

--- a/src/com/cloudogu/ces/cesbuildlib/Docker.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Docker.groovy
@@ -21,7 +21,7 @@ class Docker implements Serializable {
     String findIp(container) {
         sh.returnStdOut "docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${container.id}"
     }
-
+    
     /**
      * @return the IP address in the current context: the docker host ip (when outside of a container) or the ip of the
      * container this is running in
@@ -288,6 +288,22 @@ class Docker implements Serializable {
             }
             this.dockerClientVersionToInstall = version
             return this
+        }
+
+        /**
+         * Returns the repo digests, a content addressable unique digest of an image that was pushed  to or pulled from
+         * a repository.  
+         *    
+         * @return If the image was built locally and not pushed, returns an empty list.
+         *  If the image was pulled from or pushed to a repo, returns a list containing one item.
+         *  If the image was pulled from or pushed to multiple repos, might also contain more than one digest.
+         */
+        List repoDigests() {
+            def split = sh.returnStdOut(
+                    "docker image inspect ${imageIdString} -f '{{range .RepoDigests}}{{printf \"%s\\n\" .}}{{end}}'")
+                    .split('\n')
+            // Remove empty lines, e.g. the superflous last linebreak
+            return  split - ''
         }
 
         private extendArgs(String args) {

--- a/src/com/cloudogu/ces/cesbuildlib/Git.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Git.groovy
@@ -198,6 +198,23 @@ class Git implements Serializable {
     }
 
     /**
+     * @return true when changes are staged for commit, i.e. "git add" detected changes.
+     * Note that this will not work on a branch which has no commits, e.g. newly initialized repositories.
+     */
+    boolean areChangesStagedForCommit() {
+        // See https://stackoverflow.com/a/3879077/
+        
+        // '--' at the end avoids matching a file called "HEAD" 
+        String returnCode = script.sh(returnStatus: true, script: 'git update-index --refresh && git diff-index --exit-code HEAD --')
+        // --exit-code: exits with 1 if there were differences and 0 means no differences.
+        if (returnCode.equals("0")) {
+            return false
+        } else {
+            true
+        }
+    }
+
+    /**
      * Sets Tag with message using the name and email of the last committer as author and committer.
      *
      * @param tag

--- a/src/com/cloudogu/ces/cesbuildlib/SonarQube.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/SonarQube.groovy
@@ -136,11 +136,19 @@ class SonarQube implements Serializable {
             // CHANGE_TARGET=develop
             
             def artifactId = mvn.artifactId.trim()
-            mvn.additionalArgs += " -Dsonar.projectKey=${mvn.groupId}:${artifactId}:${script.env.BRANCH_NAME}"  +
-                    " -Dsonar.projectName=${artifactId}:${script.env.BRANCH_NAME} "
+            // Malformed key for Project: 'groupId:artifactId:feature/something'. 
+            // Allowed characters are alphanumeric, '-', '_', '.' and ':', with at least one non-digit.
+            String projectKey = replaceCharactersNotAllowedInProjectKey(script.env.BRANCH_NAME)
+            String projectName = script.env.BRANCH_NAME
+            mvn.additionalArgs += " -Dsonar.projectKey=${mvn.groupId}:${artifactId}:${projectKey}"  +
+                    " -Dsonar.projectName=${artifactId}:${projectName} "
         }
     }
 
+    protected String replaceCharactersNotAllowedInProjectKey(String potentialProjectKey) {
+        return potentialProjectKey.replaceAll("[^a-zA-Z0-9-_.:]", "_");
+    }
+    
     protected String determineIntegrationBranch() {
         if (config['integrationBranch']) {
             return config['integrationBranch']

--- a/test/com/cloudogu/ces/cesbuildlib/GitTest.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/GitTest.groovy
@@ -126,6 +126,18 @@ class GitTest {
     }
 
     @Test
+    void changesStagedForCommit() {
+        scriptMock.expectedDefaultShRetValue = 1
+        assertTrue git.areChangesStagedForCommit()
+    }
+
+    @Test
+    void noChangesStagedForCommit() {
+        scriptMock.expectedDefaultShRetValue = 0
+        assertFalse git.areChangesStagedForCommit()
+    }
+
+    @Test
     void getRepositoryUrl() {
         String expectedReturnValue = "https://github.com/orga/repo.git"
         scriptMock.expectedDefaultShRetValue = expectedReturnValue + " \n"


### PR DESCRIPTION
Adds

* `Git.areChangesStagedForCommit()` and
* `Docker.Image.repoDigests()`

Fixes
* Exception when using `Docker.Image.push()` and `tag()`: `Scripts not permitted to use field org.jenkinsci.plugins.docker.workflow.ImageNameTokens tag`
* SonarQube: "Malformed key for Project" when not using branch plugin. " because this broke the built.