### PR TITLE
#96 Add docker and shell linter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Function lintDockerfile to lint docker files #96.
+- Function shellCheck to lint shell scripts #96.
 
 ## [1.60.1](https://github.com/cloudogu/ces-build-lib/releases/tag/1.60.1) - 2022-12-01
 ### Fixed
@@ -17,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.59.0](https://github.com/cloudogu/ces-build-lib/releases/tag/1.59.0) - 2022-11-28
 ### Added
-- Function `collectAndArchiveLogs` to collect dogu and resource information to help debugging k3s Jenkins buils. #89 
+- Function `collectAndArchiveLogs` to collect dogu and resource information to help debugging k3s Jenkins builds. #89 
 - Function `applyDoguResource(String doguName, String doguNamespace, String doguVersion)` to apply a custom dogu 
   resource into the cluster. This effectively installs a dogu if it is available. #89 
 

--- a/README.md
+++ b/README.md
@@ -1140,7 +1140,7 @@ Example:
 
 # Markdown
 
-`Markdown` provides function regardig the `Markdown Files` from the projects docs directory  
+`Markdown` provides function regarding the `Markdown Files` from the projects docs directory  
 
 ```groovy
     Markdown markdown = new Markdown(this)
@@ -1150,6 +1150,23 @@ Example:
 `markdown.check` executes the function defined in `Markdown`
 running a container with the latest https://github.com/tcort/markdown-link-check image
 and verifies that the links in the defined project directory are alive
+
+### DockerLint
+
+```groovy
+lintDockerfile() // uses Dockerfile as default; optional parameter
+```
+
+See [lintDockerFile](vars/lintDockerfile.groovy)
+
+### ShellCheck
+
+```groovy
+shellCheck() // search for all .sh files in folder and runs shellcheck
+shellCheck(fileList) // fileList="a.sh b.sh" execute shellcheck on a custom list
+```
+
+See [shellCheck](vars/shellCheck.groovy)
 
 # Steps
 

--- a/vars/lintDockerfile.groovy
+++ b/vars/lintDockerfile.groovy
@@ -1,0 +1,8 @@
+package com.cloudogu.ces.cesbuildlib
+
+def call(String dockerfile = "Dockerfile") {
+    // only latest version available
+    docker.image('projectatomic/dockerfile-lint:latest').inside({
+        sh "dockerfile_lint -p -f ${dockerfile}"
+    })
+}

--- a/vars/shellCheck.groovy
+++ b/vars/shellCheck.groovy
@@ -1,0 +1,35 @@
+/**
+ * shellcheck for jenkins-pipelines https://github.com/koalaman/shellcheck
+ *
+ */
+package com.cloudogu.ces.cesbuildlib
+
+/**
+ * run shellcheck with a custom fileList
+ * sample input "test1.sh", "test2.sh"
+ *
+ */
+def call(fileList) {
+    executeWithDocker(fileList)
+}
+
+/**
+ * run shellcheck on every .sh file inside the project folder
+ * note: it ignores ./ecosystem folder for usage with ecosystem instances
+ *
+ */
+def call() {
+        def fileList = sh (script: 'find . -path ./ecosystem -prune -o -type f -regex .*\\.sh -print', returnStdout: true)
+        fileList='"' + fileList.trim().replaceAll('\n','" "') + '"'
+        executeWithDocker(fileList)
+}
+
+/*
+* run the alpine based shellcheck image
+* note: we encountered some problems while using the minified docker image
+*/
+private def executeWithDocker(fileList){
+    docker.image('koalaman/shellcheck-alpine:stable').inside(){
+        sh "/bin/shellcheck ${fileList}"
+    }
+}


### PR DESCRIPTION
Move functions from the ´dogu-build-lib´ to the ´ces-build-lib´ because components like the dogu-operator can use them.

Resolves #96 