### PR TITLE
Bugfix/trivy scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.65.1]
 
 - `findVulnerabilitiesWithTrivy` schema bug fix
   - The trivy output scheme is now interpreted correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `findVulnerabilitiesWithTrivy` schema bug fix
+  - The trivy output scheme is now interpreted correctly
+  - Added `additionalFlags` as parameter e.g. '--ingore-unfixed' can be used now
+
 ## [1.65.0](https://github.com/cloudogu/ces-build-lib/releases/tag/1.65.0) - 2023-06-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1239,7 +1239,8 @@ Returns a list of vulnerabilities or an empty list if there are no vulnerabiliti
 trivyConfig = [ 
     imageName: 'alpine:3.17.2', 
     severity: [ 'HIGH, CRITICAL' ], 
-    trivyVersion: '0.41.0'
+    trivyVersion: '0.41.0',
+    additionalFlags: '--ignore-unfixed'
 ]
 ```
 
@@ -1249,6 +1250,7 @@ Here the only mandatory field is `imageName`. If no imageName was passed the fun
 - **severity** *(list of strings)*: If left blank all severities will be shown. If one or more are specified only these will be shown
   i.e. if 'HIGH' is passed then only vulnerabilities with the 'HIGH' score are shown
 - **trivyVersion** *(string)*: The version of the trivy image
+- **additionalFlags** *(string)*: Additional flags for trivy, e.g. `--ignore-unfixed`
 
 ### Simple examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.cloudogu.ces</groupId>
     <artifactId>ces-build-lib</artifactId>
     <name>ces-build-lib</name>
-    <version>1.64.2</version>
+    <version>1.65.1</version>
 
 
     <properties>

--- a/vars/findVulnerabilitiesWithTrivy.groovy
+++ b/vars/findVulnerabilitiesWithTrivy.groovy
@@ -1,51 +1,61 @@
 package com.cloudogu.ces.cesbuildlib
-//findVulnerabilitiesWithTrivy([ imageName: 'nginx', severity=[ 'HIGH, CRITICAL' ], trivyVersion: '0.41.0' ])
+
+//findVulnerabilitiesWithTrivy([ imageName: 'nginx', severity=[ 'HIGH, CRITICAL' ], additionalFlags: '--ignore-unfixed' ,trivyVersion: '0.41.0' ])
 // Use a .trivyignore file for allowed CVEs
 // If no vulnerabilities are found or no imageName was passed an empty List is returned
 // Otherwise the list with all vulnerabilities (excluding the ones in the .trivyignore if one was passed)
 ArrayList call (Map args) {
-
+    //imageName is mandatory
     if(validateArgs(args)) {
         if(args.containsKey('allowList'))
             error "Arg allowList is deprecated, please use .trivyignore file"
         def imageName = args.imageName
         def trivyVersion = args.trivyVersion ? args.trivyVersion : '0.41.0'
         def severityFlag = args.severity ? "--severity=${args.severity.join(',')}" : ''
+        def additionalFlags = args.additionalFlags ? args.additionalFlags : ''
         println(severityFlag)
 
 
         sh "mkdir -p .trivy/.cache"
 
-        return getVulnerabilities(trivyVersion as String, severityFlag as String, imageName as String)
+        return getVulnerabilities(trivyVersion as String, severityFlag as String, additionalFlags as String, imageName as String)
     } else {
         error "There was no imageName to be processed. An imageName is mandatory to check for vulnerabilities."
         return []
     }
 }
 
-ArrayList getVulnerabilities(String trivyVersion, String severityFlag, String imageName) {
+ArrayList getVulnerabilities(String trivyVersion, String severityFlag, String additionalFlags,String imageName) {
     // this runs trivy and creates an output file with found vulnerabilities
-    runTrivyInDocker(trivyVersion, severityFlag, imageName)
+    runTrivyInDocker(trivyVersion, severityFlag, additionalFlags, imageName)
 
     def trivyOutput = readJSON file: "${env.WORKSPACE}/.trivy/trivyOutput.json"
 
-    if(trivyOutput.Results[0].Vulnerabilities == null || trivyOutput.Results[0].Vulnerabilities.equals("null")) {
-        return []
-    } else {
-        def vulnerabilities = trivyOutput.Results[0].Vulnerabilities as ArrayList
-        return vulnerabilities
+    def vulnerabilities = []
+    for (int i = 0; i < trivyOutput.Results.size(); i++) {
+
+        if(trivyOutput.Results[i].Vulnerabilities != null ) {
+            vulnerabilities += trivyOutput.Results[i].Vulnerabilities
+        }
     }
+    return vulnerabilities
+
 }
 
-def runTrivyInDocker(String trivyVersion, severityFlag, imageName) {
+
+
+
+def runTrivyInDocker(String trivyVersion, severityFlag, additionalFlags, imageName) {
     new Docker(this).image("aquasec/trivy:${trivyVersion}")
-            .mountJenkinsUser()
-            .mountDockerSocket()
-            .inside("-v ${env.WORKSPACE}/.trivy/.cache:/root/.cache/") {
+        .mountJenkinsUser()
+        .mountDockerSocket()
+        .inside("-v ${env.WORKSPACE}/.trivy/.cache:/root/.cache/") {
 
-                sh "trivy image -f json -o .trivy/trivyOutput.json ${severityFlag} ${imageName}"
-            }
+            sh "trivy image -f json -o .trivy/trivyOutput.json ${severityFlag} ${additionalFlags} ${imageName}"
+        }
 }
+
+
 
 static boolean validateArgs(Map args) {
     return !(args == null || args.imageName == null || args.imageName == '')


### PR DESCRIPTION
Noticed a bug while working on https://ecosystem.cloudogu.com/redmine/issues/36571. Only the first result of the scanned packages was returned. This could lead to 0 vulnerabilities if the first didn't contain any, but the rest of the packages did. 

Also added the possibilty to read additional flags. Most likely to filter with '--ignore-unfixed' 