### PR TITLE
Switch to hadolint Dockerfile linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Switch to hadolint Dockerfile linter; #111
 
+### Added
+- Add Dockerfile class with new linting functions; #111
+  - `lint()` lints with default hadolint config parameters. Only fails on errors
+  - `lintWithConfig()` lets you specify the hadolint configuration
+
+### Deprecated
+- `lintDockerfile()` function should be replaced by the Dockerfile `lint()` function
+
 ## [1.66.0](https://github.com/cloudogu/ces-build-lib/releases/tag/1.66.0) - 2023-08-21
 ### Added
 - Add helm-repo-config to k3d-cluster #109.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Changed
+- Switch to hadolint Dockerfile linter; #111
 
 ## [1.66.0](https://github.com/cloudogu/ces-build-lib/releases/tag/1.66.0) - 2023-08-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Jenkins Pipeline Shared library, that contains additional features for Git, Mave
   - [Additional features provided by the `Docker` class](#additional-features-provided-by-the-docker-class)
   - [`Docker.Image` methods provided by the docker plugin](#dockerimage-methods-provided-by-the-docker-plugin)
   - [Additional features provided by the `Docker.Image` class](#additional-features-provided-by-the-dockerimage-class)
+- [Dockerfile](#dockerfile)
 - [SonarQube](#sonarqube)
   - [Constructors](#constructors)
   - [A complete example](#a-complete-example)
@@ -712,6 +713,22 @@ new Docker(this).image('kkarczmarczyk/node-yarn:8.0-wheezy')
     }
 ```
 
+# Dockerfile
+
+The `Dockerfile` class provides functions to lint Dockerfiles. For example:
+
+```groovy
+stage('Lint') {
+    Dockerfile dockerfile = new Dockerfile(this)
+    dockerfile.lintDefault() // Lint with default parameters. Fails only on errors.
+    dockerfile.lint() // Use your own hadolint configuration with a .hadolint.yaml configuration file
+}
+```
+
+The tool [hadolint](https://github.com/hadolint/hadolint) is used for linting. It has a lot of configuration parameters
+which can be set by creating a `.hadolint.yaml` file in your working directory.
+See https://github.com/hadolint/hadolint#configure
+
 # SonarQube
 
 When analyzing code with SonarQube there are a couple of challenges that are solved using ces-build-lib's 
@@ -1159,7 +1176,10 @@ Additionally, the markdown link checker can be used with a specific version (def
     markdown.check()
 ```
 
-### DockerLint
+### DockerLint (Deprecated)
+
+Use Dockerfile.lintDefault() instead of lintDockerfile()!
+See [Dockerfile](#dockerfile)
 
 ```groovy
 lintDockerfile() // uses Dockerfile as default; optional parameter

--- a/README.md
+++ b/README.md
@@ -720,8 +720,8 @@ The `Dockerfile` class provides functions to lint Dockerfiles. For example:
 ```groovy
 stage('Lint') {
     Dockerfile dockerfile = new Dockerfile(this)
-    dockerfile.lintDefault() // Lint with default parameters. Fails only on errors.
-    dockerfile.lint() // Use your own hadolint configuration with a .hadolint.yaml configuration file
+    dockerfile.lint() // Lint with default configuration
+    dockerfile.lintWithConfig() // Use your own hadolint configuration with a .hadolint.yaml configuration file
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1178,7 +1178,7 @@ Additionally, the markdown link checker can be used with a specific version (def
 
 ### DockerLint (Deprecated)
 
-Use Dockerfile.lintDefault() instead of lintDockerfile()!
+Use Dockerfile.lint() instead of lintDockerfile()!
 See [Dockerfile](#dockerfile)
 
 ```groovy

--- a/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
@@ -1,0 +1,20 @@
+package com.cloudogu.ces.cesbuildlib
+
+class Dockerfile {
+    private script
+    private Sh sh
+
+    Dockerfile(script) {
+        this.script = script
+        this.sh = new Sh(script)
+    }
+
+    /**
+     * Lints the Dockerfile with the latest version of hadolint
+     */
+    void lint(){
+        docker.image('hadolint/hadolint:latest-debian').inside(){
+            sh "hadolint Dockerfile"
+        }
+    }
+}

--- a/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
@@ -8,14 +8,17 @@ class Dockerfile {
     }
 
     /**
-     * Lints the Dockerfile with the latest version of hadolint
+     * Lints the Dockerfile with hadolint using a configuration file
      *
      * To configure hadelint, add a ".hadolint.yaml" file to your working directory
      * See https://github.com/hadolint/hadolint#configure
+     *
+     * @param dockerfile Path to the Dockerfile that should be linted
+     * @param configuration Path to the hadolint configuration file
      */
-    void lint(String dockerfile = "Dockerfile"){
+    void lintWithConfig(String dockerfile = "Dockerfile", String configuration = ".hadolint.yaml"){
         script.docker.image('hadolint/hadolint:latest-debian').inside(){
-            script.sh "hadolint ${dockerfile}"
+            script.sh "hadolint --no-color -c ${configuration} ${dockerfile}"
         }
     }
 
@@ -24,7 +27,7 @@ class Dockerfile {
      * Only fails on errors, ignores warnings etc.
      * Trusts registries docker.io, gcr.io and registry.cloudogu.com
      */
-    void lintDefault(String dockerfile = "Dockerfile"){
+    void lint(String dockerfile = "Dockerfile"){
         script.docker.image('hadolint/hadolint:latest-debian').inside(){
             script.sh "hadolint -t error --no-color --trusted-registry docker.io --trusted-registry gcr.io --trusted-registry registry.cloudogu.com ${dockerfile}"
         }

--- a/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
@@ -9,10 +9,24 @@ class Dockerfile {
 
     /**
      * Lints the Dockerfile with the latest version of hadolint
+     *
+     * To configure hadelint, add a ".hadolint.yaml" file to your working directory
+     * See https://github.com/hadolint/hadolint#configure
      */
-    void lint(){
+    void lint(String dockerfile = "Dockerfile"){
         script.docker.image('hadolint/hadolint:latest-debian').inside(){
-            script.sh "hadolint Dockerfile"
+            script.sh "hadolint ${dockerfile}"
+        }
+    }
+
+    /**
+     * Lints the Dockerfile with the latest version of hadolint
+     * Only fails on errors, ignores warnings etc.
+     * Trusts registries docker.io, gcr.io and registry.cloudogu.com
+     */
+    void lintDefault(String dockerfile = "Dockerfile"){
+        script.docker.image('hadolint/hadolint:latest-debian').inside(){
+            script.sh "hadolint -t error --no-color --trusted-registry docker.io --trusted-registry gcr.io --trusted-registry registry.cloudogu.com ${dockerfile}"
         }
     }
 }

--- a/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
@@ -2,19 +2,17 @@ package com.cloudogu.ces.cesbuildlib
 
 class Dockerfile {
     private script
-    private Sh sh
 
     Dockerfile(script) {
         this.script = script
-        this.sh = new Sh(script)
     }
 
     /**
      * Lints the Dockerfile with the latest version of hadolint
      */
     void lint(){
-        docker.image('hadolint/hadolint:latest-debian').inside(){
-            sh "hadolint Dockerfile"
+        script.docker.image('hadolint/hadolint:latest-debian').inside(){
+            script.sh "hadolint Dockerfile"
         }
     }
 }

--- a/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/Dockerfile.groovy
@@ -15,9 +15,10 @@ class Dockerfile {
      *
      * @param dockerfile Path to the Dockerfile that should be linted
      * @param configuration Path to the hadolint configuration file
+     * @param hadolintVersion Version of the hadolint/hadolint container image
      */
-    void lintWithConfig(String dockerfile = "Dockerfile", String configuration = ".hadolint.yaml"){
-        script.docker.image('hadolint/hadolint:latest-debian').inside(){
+    void lintWithConfig(String dockerfile = "Dockerfile", String configuration = ".hadolint.yaml", hadolintVersion = "latest-debian"){
+        script.docker.image("hadolint/hadolint:${hadolintVersion}").inside(){
             script.sh "hadolint --no-color -c ${configuration} ${dockerfile}"
         }
     }
@@ -26,9 +27,12 @@ class Dockerfile {
      * Lints the Dockerfile with the latest version of hadolint
      * Only fails on errors, ignores warnings etc.
      * Trusts registries docker.io, gcr.io and registry.cloudogu.com
+     *
+     * @param dockerfile Path to the Dockerfile that should be linted
+     * @param hadolintVersion Version of the hadolint/hadolint container image
      */
-    void lint(String dockerfile = "Dockerfile"){
-        script.docker.image('hadolint/hadolint:latest-debian').inside(){
+    void lint(String dockerfile = "Dockerfile", hadolintVersion = "latest-debian"){
+        script.docker.image("hadolint/hadolint:${hadolintVersion}").inside(){
             script.sh "hadolint -t error --no-color --trusted-registry docker.io --trusted-registry gcr.io --trusted-registry registry.cloudogu.com ${dockerfile}"
         }
     }

--- a/vars/lintDockerfile.groovy
+++ b/vars/lintDockerfile.groovy
@@ -1,5 +1,6 @@
 package com.cloudogu.ces.cesbuildlib
 
+@Deprecated
 def call(String dockerfile = "Dockerfile") {
     docker.image('hadolint/hadolint:latest-debian').inside(){
         sh "hadolint --no-color -t error " +

--- a/vars/lintDockerfile.groovy
+++ b/vars/lintDockerfile.groovy
@@ -1,8 +1,9 @@
 package com.cloudogu.ces.cesbuildlib
 
 def call(String dockerfile = "Dockerfile") {
-    // only latest version available
-    docker.image('projectatomic/dockerfile-lint:latest').inside({
-        sh "dockerfile_lint -p -f ${dockerfile}"
-    })
+    docker.image('hadolint/hadolint:latest-debian').inside(){
+        sh "hadolint --no-color -t error " +
+            "--trusted-registry docker.io --trusted-registry gcr.io --trusted-registry registry.cloudogu.com " +
+            "${WORKSPACE}/${dockerfile}"
+    }
 }


### PR DESCRIPTION
### Changed
- Switch to hadolint Dockerfile linter; #111

### Added
- Add Dockerfile class with new linting functions; #111
  - `lint()` lints with default hadolint config parameters. Only fails on errors
  - `lintWithConfig()` lets you specify the hadolint configuration

### Deprecated
- `lintDockerfile()` function should be replaced by the Dockerfile `lint()` function

Resolves #111 