### PR TITLE
Implement Maven mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- `Maven.useMirrors([name: 'maven-proxy', mirrorOf: 'central', url: 'https://maven.example.org'])`
 
 ## [2.1.0](https://github.com/cloudogu/ces-build-lib/releases/tag/2.1.0) - 2024-01-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -278,12 +278,22 @@ mvn {
 }
 ```
 
+## Mirrors
+
+You can define maven mirrors as follows:
+
+```groovy
+Maven.useMirrors([name: 'maven-proxy', mirrorOf: 'central', url: 'https://maven.example.org'],
+                 [name: 'google-maven', mirrorOf: 'central', url: 'https://maven-central.storage.googleapis.com/maven2/'],
+)
+````
+
 ## Repository Credentials
 
 If you specified one or more `<repository>` in your `pom.xml` that requires authentication, you can pass these 
 credentials to your ces-build-lib `Maven` instance like so:
 
-```bash
+```groovy
 mvn.useRepositoryCredentials([id: 'ces', credentialsId: 'nexusSystemUserCredential'],
                              [id: 'another', credentialsId: 'nexusSystemUserCredential'])
 ```


### PR DESCRIPTION
Can be tested with the GitOps Playground for example:

http://scmm.localhost/scm/repo/argocd/petclinic-plain/code/sources/main/Jenkinsfile/

Then change these lines:

```java
String getCesBuildLibRepo() { "https://github.com/cloudogu/ces-build-lib/" }
String getCesBuildLibVersion() { '7e7e858' }


//. ..
node {

    mvn = cesBuildLib.MavenWrapper.new(this)
    mvn.useMirrors([name: 'google-maven', mirrorOf: 'central', url: 'https://maven-central.storage.googleapis.com/maven2/'])
    
    catchError {

        stage('Checkout') {
            checkout scm
        }

        stage('Build') {
            mvn 'clean package -DskipTests -Dcheckstyle.skip'
            archiveArtifacts artifacts: '**/target/*.jar'
        }
    
// ... def loadLibraries() 

    cesBuildLib = library(identifier: "ces-build-lib@${cesBuildLibVersion}",
            retriever: modernSCM([$class: 'GitSCMSource', remote: cesBuildLibRepo])
    ).com.cloudogu.ces.cesbuildlib

```

Then start a build on Jenkins:  http://jenkins.localhost/job/example-apps/job/petclinic-plain/job/main/build?delay=0sec

An in the logs of this build you will see the mirror in action
![image](https://github.com/cloudogu/ces-build-lib/assets/1824962/586958b4-b889-439b-b4ed-4f6c0d2cbd23)
