### PR TITLE
Check changelog and release notes on open PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- Add checkChangelog function to make sure your changelog has been updated on an open PR
+- Add checkReleaseNotes function to make sure your release notes have been updated on an open PR
 
 ## [4.0.1](https://github.com/cloudogu/ces-build-lib/releases/tag/4.0.1) - 2025-01-07
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Jenkins Pipeline Shared library, that contains additional features for Git, Mave
   - [findEmailRecipients](#findemailrecipients)
   - [findHostName](#findhostname)
   - [isBuildSuccessful](#isbuildsuccessful)
+  - [checkChangelog](#checkchangelog)
+  - [checkReleaseNotes](#checkreleasenotes)
   - [findVulnerabilitiesWithTrivy](#findvulnerabilitieswithtrivy)
     - [Simple examples](#simple-examples)
     - [Ignore / allowlist](#ignore--allowlist)
@@ -1466,6 +1468,30 @@ For example, if running on `http(s)://server:port/jenkins`, `server` is returned
 ## isBuildSuccessful
 
 Returns true if the build is successful, i.e. not failed or unstable (yet).
+
+## checkChangelog
+
+Automatically check if your changelog has been updated if a PR is created.
+If the changelog has not been updated, the build will become unstable.
+
+Usage:
+
+```groovy
+Changelog changelog = new Changelog(this)
+checkChangelog(changelog)
+```
+
+## checkReleaseNotes
+
+Automatically check if your release notes have been updated if a PR is created.
+If the release notes have not been updated, the build will become unstable.
+
+Usage:
+
+```groovy
+ReleaseNotes releaseNotes = new ReleaseNotes(this)
+checkReleaseNotes(releaseNotes)
+```
 
 ## findVulnerabilitiesWithTrivy (Deprecated)
 

--- a/src/com/cloudogu/ces/cesbuildlib/ReleaseNotes.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/ReleaseNotes.groovy
@@ -26,6 +26,13 @@ class ReleaseNotes implements Serializable {
     }
 
     /**
+     * @return Returns the content of english release notes file.
+     */
+    private String readReleaseNotesEN(){
+        script.readFile releaseNotesFileNameEN
+    }
+
+    /**
      * Extracts the changes for a given version out of the german release notes.
      *
      * @param releaseVersion The version to get the changes for.
@@ -36,6 +43,19 @@ class ReleaseNotes implements Serializable {
         def start = changesStartIndex(releaseNotesDE, releaseVersion)
         def end = changesEndIndex(releaseNotesDE, start)
         return escapeForJson(releaseNotesDE.substring(start, end).trim())
+    }
+
+    /**
+     * Extracts the changes for a given version out of the english release notes.
+     *
+     * @param releaseVersion The version to get the changes for.
+     * @return Returns the changes as String.
+     */
+    String changesForENVersion(String releaseVersion) {
+        def releaseNotesEN = readReleaseNotesEN()
+        def start = changesStartIndex(releaseNotesEN, releaseVersion)
+        def end = changesEndIndex(releaseNotesEN, start)
+        return escapeForJson(releaseNotesEN.substring(start, end).trim())
     }
 
     /**
@@ -53,31 +73,31 @@ class ReleaseNotes implements Serializable {
     }
 
     /**
-     * Returns the start index of changes of a specific release version in the german release notes.
+     * Returns the start index of changes of a specific release version in the release notes.
      *
      * @param releaseVersion The version to get the changes for.
      * @return Returns the index in the release notes string where the changes start.
      */
-    private static int changesStartIndex(String releaseNotesDE, String releaseVersion) {
-        def index = releaseNotesDE.indexOf("## [${releaseVersion}]")
+    private static int changesStartIndex(String releaseNotes, String releaseVersion) {
+        def index = releaseNotes.indexOf("## [${releaseVersion}]")
         if (index == -1){
             throw new IllegalArgumentException("The desired version '${releaseVersion}' could not be found in the release notes.")
         }
-        def offset = releaseNotesDE.substring(index).indexOf("\n")
+        def offset = releaseNotes.substring(index).indexOf("\n")
         return index + offset
     }
 
     /**
-     * Returns the end index of changes of a specific release version in the german release notes.
+     * Returns the end index of changes of a specific release version in the release notes.
      *
      * @param start The start index of the changes for this version.
      * @return Returns the index in the release notes string where the changes end.
      */
-    private static int changesEndIndex(String releaseNotesDE, int start) {
-        def releaseNotesAfterStartIndex = releaseNotesDE.substring(start)
+    private static int changesEndIndex(String releaseNotes, int start) {
+        def releaseNotesAfterStartIndex = releaseNotes.substring(start)
         def index = releaseNotesAfterStartIndex.indexOf("\n## [")
         if (index == -1) {
-            return releaseNotesDE.length()
+            return releaseNotes.length()
         }
         return index + start
     }

--- a/src/com/cloudogu/ces/cesbuildlib/ReleaseNotes.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/ReleaseNotes.groovy
@@ -1,0 +1,84 @@
+package com.cloudogu.ces.cesbuildlib
+
+/**
+ * Enables interaction with release notes files
+ */
+class ReleaseNotes implements Serializable {
+    private script
+    private String releaseNotesFileNameDE
+    private String releaseNotesFileNameEN
+
+    ReleaseNotes(script) {
+        this(script, 'docs/gui/releasenotes_de.md', 'docs/gui/releasenotes_en.md')
+    }
+
+    ReleaseNotes(script, releaseNotesFileNameDE, releaseNotesFileNameEN) {
+        this.script = script
+        this.releaseNotesFileNameDE = releaseNotesFileNameDE
+        this.releaseNotesFileNameEN = releaseNotesFileNameEN
+    }
+
+    /**
+     * @return Returns the content of german release notes file.
+     */
+    private String readReleaseNotesDE(){
+        script.readFile releaseNotesFileNameDE
+    }
+
+    /**
+     * Extracts the changes for a given version out of the german release notes.
+     *
+     * @param releaseVersion The version to get the changes for.
+     * @return Returns the changes as String.
+     */
+    String changesForDEVersion(String releaseVersion) {
+        def releaseNotesDE = readReleaseNotesDE()
+        def start = changesStartIndex(releaseNotesDE, releaseVersion)
+        def end = changesEndIndex(releaseNotesDE, start)
+        return escapeForJson(releaseNotesDE.substring(start, end).trim())
+    }
+
+    /**
+     * Removes characters from a string that could break the json struct when passing the string as json value.
+     *
+     * @param string The string to format.
+     * @return Returns the formatted string.
+     */
+    private static String escapeForJson(String string) {
+        return string
+                .replace("\"", "")
+                .replace("'", "")
+                .replace("\\", "")
+                .replace("\n", "\\n")
+    }
+
+    /**
+     * Returns the start index of changes of a specific release version in the german release notes.
+     *
+     * @param releaseVersion The version to get the changes for.
+     * @return Returns the index in the release notes string where the changes start.
+     */
+    private static int changesStartIndex(String releaseNotesDE, String releaseVersion) {
+        def index = releaseNotesDE.indexOf("## [${releaseVersion}]")
+        if (index == -1){
+            throw new IllegalArgumentException("The desired version '${releaseVersion}' could not be found in the release notes.")
+        }
+        def offset = releaseNotesDE.substring(index).indexOf("\n")
+        return index + offset
+    }
+
+    /**
+     * Returns the end index of changes of a specific release version in the german release notes.
+     *
+     * @param start The start index of the changes for this version.
+     * @return Returns the index in the release notes string where the changes end.
+     */
+    private static int changesEndIndex(String releaseNotesDE, int start) {
+        def releaseNotesAfterStartIndex = releaseNotesDE.substring(start)
+        def index = releaseNotesAfterStartIndex.indexOf("\n## [")
+        if (index == -1) {
+            return releaseNotesDE.length()
+        }
+        return index + start
+    }
+}

--- a/src/com/cloudogu/ces/cesbuildlib/ReleaseNotes.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/ReleaseNotes.groovy
@@ -9,7 +9,7 @@ class ReleaseNotes implements Serializable {
     private String releaseNotesFileNameEN
 
     ReleaseNotes(script) {
-        this(script, 'docs/gui/releasenotes_de.md', 'docs/gui/releasenotes_en.md')
+        this(script, 'docs/gui/release_notes_de.md', 'docs/gui/release_notes_en.md')
     }
 
     ReleaseNotes(script, releaseNotesFileNameDE, releaseNotesFileNameEN) {

--- a/vars/checkChangelog.groovy
+++ b/vars/checkChangelog.groovy
@@ -8,10 +8,5 @@ def call(Changelog changelog = new Changelog(this), ReleaseNotes releaseNotes = 
         if (!newChanges || newChanges.allWhitespace) {
             unstable('CHANGELOG.md should contain new change entries in the `[Unreleased]` section but none were found.')
         }
-        echo "Checking release notes..."
-        String newChangesReleaseNotes = releaseNotes.changesForDEVersion("Unreleased")
-        if (!newChangesReleaseNotes || newChangesReleaseNotes.allWhitespace) {
-            unstable('Release Notes should contain new change entries in the `[Unreleased]` section but none were found.')
-        }
     }
 }

--- a/vars/checkChangelog.groovy
+++ b/vars/checkChangelog.groovy
@@ -1,6 +1,6 @@
 package com.cloudogu.ces.cesbuildlib
 
-def call(Changelog changelog = new Changelog(this), ReleaseNotes releaseNotes = new ReleaseNotes(this)) {
+def call(Changelog changelog = new Changelog(this)) {
     // Checking if this is associated with a pull request
     if (env.CHANGE_TARGET) {
         echo "Checking changelog..."

--- a/vars/checkPullRequest.groovy
+++ b/vars/checkPullRequest.groovy
@@ -1,0 +1,17 @@
+package com.cloudogu.ces.cesbuildlib
+
+def call(Changelog changelog = new Changelog(this), ReleaseNotes releaseNotes = new ReleaseNotes(this)) {
+    // Checking if this is associated with a pull request
+    if (env.CHANGE_TARGET) {
+        echo "Checking changelog..."
+        String newChanges = changelog.changesForVersion('Unreleased')
+        if (!newChanges || newChanges.allWhitespace) {
+            unstable('CHANGELOG.md should contain new change entries in the `[Unreleased]` section but none were found.')
+        }
+        echo "Checking release notes..."
+        String newChangesReleaseNotes = releaseNotes.changesForDEVersion("Unreleased")
+        if (!newChangesReleaseNotes || newChangesReleaseNotes.allWhitespace) {
+            unstable('Release Notes should contain new change entries in the `[Unreleased]` section but none were found.')
+        }
+    }
+}

--- a/vars/checkReleaseNotes.groovy
+++ b/vars/checkReleaseNotes.groovy
@@ -1,6 +1,6 @@
 package com.cloudogu.ces.cesbuildlib
 
-def call(Changelog changelog = new Changelog(this), ReleaseNotes releaseNotes = new ReleaseNotes(this)) {
+def call(ReleaseNotes releaseNotes = new ReleaseNotes(this)) {
     // Checking if this is associated with a pull request
     if (env.CHANGE_TARGET) {
         echo "Checking release notes..."

--- a/vars/checkReleaseNotes.groovy
+++ b/vars/checkReleaseNotes.groovy
@@ -4,9 +4,13 @@ def call(ReleaseNotes releaseNotes = new ReleaseNotes(this)) {
     // Checking if this is associated with a pull request
     if (env.CHANGE_TARGET) {
         echo "Checking release notes..."
-        String newChangesReleaseNotes = releaseNotes.changesForDEVersion("Unreleased")
-        if (!newChangesReleaseNotes || newChangesReleaseNotes.allWhitespace) {
-            unstable('Release Notes should contain new change entries in the `[Unreleased]` section but none were found.')
+        String newChangesReleaseNotesDE = releaseNotes.changesForDEVersion("Unreleased")
+        if (!newChangesReleaseNotesDE || newChangesReleaseNotesDE.allWhitespace) {
+            unstable('Release Notes should contain new change entries in the `[Unreleased]` section but none were found in the german version')
+        }
+        String newChangesReleaseNotesEN = releaseNotes.changesForENVersion("Unreleased")
+        if (!newChangesReleaseNotesEN || newChangesReleaseNotesEN.allWhitespace) {
+            unstable('Release Notes should contain new change entries in the `[Unreleased]` section but none were found in the english version')
         }
     }
 }

--- a/vars/checkReleaseNotes.groovy
+++ b/vars/checkReleaseNotes.groovy
@@ -1,0 +1,12 @@
+package com.cloudogu.ces.cesbuildlib
+
+def call(Changelog changelog = new Changelog(this), ReleaseNotes releaseNotes = new ReleaseNotes(this)) {
+    // Checking if this is associated with a pull request
+    if (env.CHANGE_TARGET) {
+        echo "Checking release notes..."
+        String newChangesReleaseNotes = releaseNotes.changesForDEVersion("Unreleased")
+        if (!newChangesReleaseNotes || newChangesReleaseNotes.allWhitespace) {
+            unstable('Release Notes should contain new change entries in the `[Unreleased]` section but none were found.')
+        }
+    }
+}


### PR DESCRIPTION
These new functions enable you to automatically check if your changelog and release notes have been updated as soon as a PR is created.