### PR TITLE
kubectl + helm install without snap

### DIFF
--- a/src/com/cloudogu/ces/cesbuildlib/K3d.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/K3d.groovy
@@ -16,6 +16,8 @@ class K3d {
     private static String K3D_VALUES_YAML_FILE = "k3d_values.yaml"
     private static String K3D_BLUEPRINT_FILE = "k3d_blueprint.yaml"
     private static String YQ_VERSION = "4.50.1"
+    private static String KUBECTL_VERSION = "1.36.2"
+    private static String HELM_VERSION = "4.2.3"
     // need to be installed before apply values.yaml
     private static String VERSION_ECOSYSTEM_CORE; // e.g.  "1.2.0"
     private static String VERSION_K8S_COMPONENT_OPERATOR_CRD; // e.g.  "1.10.1"
@@ -538,6 +540,39 @@ spec:
 
         script.echo "Installing helm..."
         script.sh script: "sudo snap install helm --classic"
+    }
+
+/**
+ * Install kubectl directly, without package manager
+ */
+    private void installKubectlManually() {
+        if (script.fileExists("/usr/local/bin/kubectl")) {
+            script.echo "kubectl already installed"
+            return
+        }
+
+        script.echo "Installing kubectl..."
+        String kubectlFile = this.sh.returnStdOut("mktemp")
+        script.sh "curl -f -o ${kubectlFile} https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+        script.sh "sudo mv ${kubectlFile} /usr/local/bin/kubectl"
+        script.sh "sudo chmod +x /usr/local/bin/kubectl"
+    }
+
+/**
+ * Install helm directly, without package manager
+ */
+    void installHelmManually() {
+        if (script.fileExists("/usr/local/bin/helm")) {
+            script.echo "helm already installed"
+            return
+        }
+
+        script.echo "Installing helm..."
+        String helmArchive = this.sh.returnStdOut("mktemp --suffix=.tar.gz")
+        script.sh "curl -f -o ${helmArchive} https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+        script.sh "sudo tar -xzf ${helmArchive} -C /usr/local/bin --strip-components=1 linux-amd64/helm"
+        script.sh "rm -f ${helmArchive}"
+        script.sh "sudo chmod +x /usr/local/bin/helm"
     }
 
     private String getExecPodName(String dogu, Integer timeout, Integer interval) {

--- a/src/com/cloudogu/ces/cesbuildlib/K3d.groovy
+++ b/src/com/cloudogu/ces/cesbuildlib/K3d.groovy
@@ -519,9 +519,9 @@ spec:
  * Installs kubectl
  */
     private void installKubectl() {
-        def kubectlStatusCode = script.sh script: "snap list kubectl", returnStatus: true
-        if (kubectlStatusCode == 0) {
-            script.echo "Kubectl already installed"
+        def statusCode = script.sh script: "command -V kubectl", returnStatus: true
+        if (statusCode == 0 || statusCode.equals("0")) {
+            script.echo "kubectl already installed"
             return
         }
 
@@ -532,8 +532,8 @@ spec:
  * Installs helm
  */
     void installHelm() {
-        def helmStatusCode = script.sh script: "snap list helm", returnStatus: true
-        if (helmStatusCode == 0 || helmStatusCode.equals("0")) {
+        def statusCode = script.sh script: "command -V helm", returnStatus: true
+        if (statusCode == 0 || statusCode.equals("0")) {
             script.echo "helm already installed"
             return
         }
@@ -546,7 +546,8 @@ spec:
  * Install kubectl directly, without package manager
  */
     private void installKubectlManually() {
-        if (script.fileExists("/usr/local/bin/kubectl")) {
+        def statusCode = script.sh script: "command -V kubectl", returnStatus: true
+        if (statusCode == 0 || statusCode.equals("0")) {
             script.echo "kubectl already installed"
             return
         }
@@ -562,7 +563,8 @@ spec:
  * Install helm directly, without package manager
  */
     void installHelmManually() {
-        if (script.fileExists("/usr/local/bin/helm")) {
+        def statusCode = script.sh script: "command -V helm", returnStatus: true
+        if (statusCode == 0 || statusCode.equals("0")) {
             script.echo "helm already installed"
             return
         }

--- a/test/com/cloudogu/ces/cesbuildlib/K3dTest.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/K3dTest.groovy
@@ -126,6 +126,73 @@ class K3dTest {
     }
 
     @Test
+    void testInstallKubectlManually_initially() {
+        // given
+        def scriptMock = new ScriptMock()
+        scriptMock.expectedShRetValueForScript.put("mktemp", "/tmp/kubectl123")
+        K3d sut = new K3d(scriptMock, "leWorkspace", "leK3dWorkSpace", "path")
+
+        // when
+        sut.installKubectlManually()
+
+        // then
+        assertThat(scriptMock.allActualArgs.size()).isEqualTo(4)
+        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("mktemp")
+        assertThat(scriptMock.allActualArgs[1].trim()).isEqualTo("curl -f -o /tmp/kubectl123 https://dl.k8s.io/release/v1.36.2/bin/linux/amd64/kubectl")
+        assertThat(scriptMock.allActualArgs[2].trim()).isEqualTo("sudo mv /tmp/kubectl123 /usr/local/bin/kubectl")
+        assertThat(scriptMock.allActualArgs[3].trim()).isEqualTo("sudo chmod +x /usr/local/bin/kubectl")
+    }
+
+    @Test
+    void testInstallKubectlManually_alreadyInstalled() {
+        // given
+        def scriptMock = new ScriptMock()
+        scriptMock.files.put("/usr/local/bin/kubectl", "")
+        K3d sut = new K3d(scriptMock, "leWorkspace", "leK3dWorkSpace", "path")
+
+        // when
+        sut.installKubectlManually()
+
+        // then
+        assertThat(scriptMock.allActualArgs).isEmpty()
+        assertThat(scriptMock.actualEcho).contains("kubectl already installed")
+    }
+
+    @Test
+    void testInstallHelmManually_initially() {
+        // given
+        def scriptMock = new ScriptMock()
+        scriptMock.expectedShRetValueForScript.put("mktemp --suffix=.tar.gz", "/tmp/helm.tar.gz")
+        K3d sut = new K3d(scriptMock, "leWorkspace", "leK3dWorkSpace", "path")
+
+        // when
+        sut.installHelmManually()
+
+        // then
+        assertThat(scriptMock.allActualArgs.size()).isEqualTo(5)
+        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("mktemp --suffix=.tar.gz")
+        assertThat(scriptMock.allActualArgs[1].trim()).isEqualTo("curl -f -o /tmp/helm.tar.gz https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz")
+        assertThat(scriptMock.allActualArgs[2].trim()).isEqualTo("sudo tar -xzf /tmp/helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm")
+        assertThat(scriptMock.allActualArgs[3].trim()).isEqualTo("rm -f /tmp/helm.tar.gz")
+        assertThat(scriptMock.allActualArgs[4].trim()).isEqualTo("sudo chmod +x /usr/local/bin/helm")
+    }
+
+    @Test
+    void testInstallHelmManually_alreadyInstalled() {
+        // given
+        def scriptMock = new ScriptMock()
+        scriptMock.files.put("/usr/local/bin/helm", "")
+        K3d sut = new K3d(scriptMock, "leWorkspace", "leK3dWorkSpace", "path")
+
+        // when
+        sut.installHelmManually()
+
+        // then
+        assertThat(scriptMock.allActualArgs).isEmpty()
+        assertThat(scriptMock.actualEcho).contains("helm already installed")
+    }
+
+    @Test
     void testStartK3d() {
         def workspaceDir = "leWorkspace"
         def k3dWorkspaceDir = "leK3dWorkSpace"

--- a/test/com/cloudogu/ces/cesbuildlib/K3dTest.groovy
+++ b/test/com/cloudogu/ces/cesbuildlib/K3dTest.groovy
@@ -121,7 +121,7 @@ class K3dTest {
 
         // then
         assertThat(scriptMock.allActualArgs.size()).isEqualTo(2)
-        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("snap list helm".trim())
+        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("command -V helm".trim())
         assertThat(scriptMock.allActualArgs[1].trim()).isEqualTo("sudo snap install helm --classic".trim())
     }
 
@@ -136,25 +136,26 @@ class K3dTest {
         sut.installKubectlManually()
 
         // then
-        assertThat(scriptMock.allActualArgs.size()).isEqualTo(4)
-        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("mktemp")
-        assertThat(scriptMock.allActualArgs[1].trim()).isEqualTo("curl -f -o /tmp/kubectl123 https://dl.k8s.io/release/v1.36.2/bin/linux/amd64/kubectl")
-        assertThat(scriptMock.allActualArgs[2].trim()).isEqualTo("sudo mv /tmp/kubectl123 /usr/local/bin/kubectl")
-        assertThat(scriptMock.allActualArgs[3].trim()).isEqualTo("sudo chmod +x /usr/local/bin/kubectl")
+        assertThat(scriptMock.allActualArgs.size()).isEqualTo(5)
+        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("command -V kubectl")
+        assertThat(scriptMock.allActualArgs[1].trim()).isEqualTo("mktemp")
+        assertThat(scriptMock.allActualArgs[2].trim()).isEqualTo("curl -f -o /tmp/kubectl123 https://dl.k8s.io/release/v1.36.2/bin/linux/amd64/kubectl")
+        assertThat(scriptMock.allActualArgs[3].trim()).isEqualTo("sudo mv /tmp/kubectl123 /usr/local/bin/kubectl")
+        assertThat(scriptMock.allActualArgs[4].trim()).isEqualTo("sudo chmod +x /usr/local/bin/kubectl")
     }
 
     @Test
     void testInstallKubectlManually_alreadyInstalled() {
         // given
         def scriptMock = new ScriptMock()
-        scriptMock.files.put("/usr/local/bin/kubectl", "")
+        scriptMock.expectedShRetValueForScript.put("command -V kubectl", 0)
         K3d sut = new K3d(scriptMock, "leWorkspace", "leK3dWorkSpace", "path")
 
         // when
         sut.installKubectlManually()
 
         // then
-        assertThat(scriptMock.allActualArgs).isEmpty()
+        assertThat(scriptMock.allActualArgs).containsExactly("command -V kubectl")
         assertThat(scriptMock.actualEcho).contains("kubectl already installed")
     }
 
@@ -169,26 +170,27 @@ class K3dTest {
         sut.installHelmManually()
 
         // then
-        assertThat(scriptMock.allActualArgs.size()).isEqualTo(5)
-        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("mktemp --suffix=.tar.gz")
-        assertThat(scriptMock.allActualArgs[1].trim()).isEqualTo("curl -f -o /tmp/helm.tar.gz https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz")
-        assertThat(scriptMock.allActualArgs[2].trim()).isEqualTo("sudo tar -xzf /tmp/helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm")
-        assertThat(scriptMock.allActualArgs[3].trim()).isEqualTo("rm -f /tmp/helm.tar.gz")
-        assertThat(scriptMock.allActualArgs[4].trim()).isEqualTo("sudo chmod +x /usr/local/bin/helm")
+        assertThat(scriptMock.allActualArgs.size()).isEqualTo(6)
+        assertThat(scriptMock.allActualArgs[0].trim()).isEqualTo("command -V helm")
+        assertThat(scriptMock.allActualArgs[1].trim()).isEqualTo("mktemp --suffix=.tar.gz")
+        assertThat(scriptMock.allActualArgs[2].trim()).isEqualTo("curl -f -o /tmp/helm.tar.gz https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz")
+        assertThat(scriptMock.allActualArgs[3].trim()).isEqualTo("sudo tar -xzf /tmp/helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm")
+        assertThat(scriptMock.allActualArgs[4].trim()).isEqualTo("rm -f /tmp/helm.tar.gz")
+        assertThat(scriptMock.allActualArgs[5].trim()).isEqualTo("sudo chmod +x /usr/local/bin/helm")
     }
 
     @Test
     void testInstallHelmManually_alreadyInstalled() {
         // given
         def scriptMock = new ScriptMock()
-        scriptMock.files.put("/usr/local/bin/helm", "")
+        scriptMock.expectedShRetValueForScript.put("command -V helm", 0)
         K3d sut = new K3d(scriptMock, "leWorkspace", "leK3dWorkSpace", "path")
 
         // when
         sut.installHelmManually()
 
         // then
-        assertThat(scriptMock.allActualArgs).isEmpty()
+        assertThat(scriptMock.allActualArgs).containsExactly("command -V helm")
         assertThat(scriptMock.actualEcho).contains("helm already installed")
     }
 
@@ -212,9 +214,9 @@ class K3dTest {
         assertThat(scriptMock.allActualArgs[4].trim()).matches("k3d registry create citest-[0-9a-f]+ --port 54321")
         assertThat(scriptMock.allActualArgs[5].trim()).startsWith("k3d cluster create citest-")
         assertThat(scriptMock.allActualArgs[6].trim()).startsWith("k3d kubeconfig merge citest-")
-        assertThat(scriptMock.allActualArgs[7].trim()).startsWith("snap list kubectl")
+        assertThat(scriptMock.allActualArgs[7].trim()).startsWith("command -V kubectl")
         assertThat(scriptMock.allActualArgs[8].trim()).startsWith("sudo snap install kubectl --classic")
-        assertThat(scriptMock.allActualArgs[9].trim()).startsWith("snap list helm")
+        assertThat(scriptMock.allActualArgs[9].trim()).startsWith("command -V helm")
         assertThat(scriptMock.allActualArgs[10].trim()).startsWith("sudo snap install helm --classic")
         assertThat(scriptMock.allActualArgs[11].trim()).startsWith("echo \"Using credentials: cesmarvin-setup\"")
         assertThat(scriptMock.allActualArgs[12].trim()).startsWith("sudo KUBECONFIG=${k3dWorkspaceDir}/.k3d/.kube/config kubectl delete secret k8s-dogu-operator-dogu-registry || true")
@@ -250,9 +252,9 @@ class K3dTest {
         assertThat(scriptMock.allActualArgs[4].trim()).matches("k3d registry create citest-[0-9a-f]+ --port 54321")
         assertThat(scriptMock.allActualArgs[5].trim()).startsWith("k3d cluster create citest-")
         assertThat(scriptMock.allActualArgs[6].trim()).startsWith("k3d kubeconfig merge citest-")
-        assertThat(scriptMock.allActualArgs[7].trim()).startsWith("snap list kubectl")
+        assertThat(scriptMock.allActualArgs[7].trim()).startsWith("command -V kubectl")
         assertThat(scriptMock.allActualArgs[8].trim()).startsWith("sudo snap install kubectl")
-        assertThat(scriptMock.allActualArgs[9].trim()).startsWith("snap list helm")
+        assertThat(scriptMock.allActualArgs[9].trim()).startsWith("command -V helm")
         assertThat(scriptMock.allActualArgs[10].trim()).startsWith("sudo snap install helm")
         assertThat(scriptMock.allActualArgs[11].trim()).startsWith("echo \"Using credentials: myBackendCredentialsID\"")
         assertThat(scriptMock.allActualArgs[12].trim()).startsWith("sudo KUBECONFIG=${k3dWorkspaceDir}/.k3d/.kube/config kubectl delete secret k8s-dogu-operator-dogu-registry || true")


### PR DESCRIPTION
This adds 2 functions `installKubectlManually` and `installHelmManually` to install the tools in an environment where _snap_ is not available.